### PR TITLE
Update remote packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ USER 0
 RUN pip3 install "weblate-odoo-component-generator @ git+https://github.com/acsone/weblate-odoo-component-generator@5c631eb7fd67c593941ed6f0b4629cf9f5f262d0"
 
 # wocg-oca needs oca-maintainer-tools to enumerate addons repos and branches
-RUN apt-get update && \
-  apt-get install -y python3-venv && \
-  python3 -m venv /opt/oca-maintainer-tools && \
+RUN python3 -m venv /opt/oca-maintainer-tools && \
   /opt/oca-maintainer-tools/bin/pip install -U pip wheel setuptools && \
   /opt/oca-maintainer-tools/bin/pip install git+https://github.com/OCA/maintainer-tools@76f737e7499538f4a133325811088c1347aa28fb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM weblate/weblate:4.14.1-1
 
 USER 0
 
-RUN pip3 install "weblate-odoo-component-generator @ git+https://github.com/acsone/weblate-odoo-component-generator@1152f66ae6d94e46199be7ab7c39dd88ba812ef6"
+RUN pip3 install "weblate-odoo-component-generator @ git+https://github.com/acsone/weblate-odoo-component-generator@5c631eb7fd67c593941ed6f0b4629cf9f5f262d0"
 
 # wocg-oca needs oca-maintainer-tools to enumerate addons repos and branches
 RUN apt-get update && \
   apt-get install -y python3-venv && \
   python3 -m venv /opt/oca-maintainer-tools && \
   /opt/oca-maintainer-tools/bin/pip install -U pip wheel setuptools && \
-  /opt/oca-maintainer-tools/bin/pip install git+https://github.com/OCA/maintainer-tools@72bb3f46a8a1f136f9033dbd9291cb294d5f53cd
+  /opt/oca-maintainer-tools/bin/pip install git+https://github.com/OCA/maintainer-tools@76f737e7499538f4a133325811088c1347aa28fb
 
 COPY wocg-oca /usr/local/bin/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     image: redis:6-alpine
     restart: unless-stopped
     # AFE 20191202: add no appendfsynconrewrite and auto aof rewrite min size options
-    command: ["redis-server", "--appendonly", "yes", "--no-appendfsync-on-rewrite", "yes", "--auto-aof-rewrite-min-size", "128mb"]
+    #command: ["redis-server", "--appendonly", "yes", "--no-appendfsync-on-rewrite", "yes", "--auto-aof-rewrite-min-size", "128mb"]
+    # SBI 20221016: use redis command from https://github.com/WeblateOrg/docker-compose/blob/main/docker-compose-https.yml
+    command: [redis-server, --save, '60', '1']
     volumes:
       - ./data/redis:/data
 networks:


### PR DESCRIPTION
Use default redis command in docker-compose
Update [weblate-odoo-component-generator](https://github.com/acsone/weblate-odoo-component-generator)
Update https://github.com/OCA/maintainer-tools

Update Dockerfile to remove installation of python3-venv since this would install python3.9 when python3.10 is already available in base image [python:3.10.7-slim-bullseye](https://github.com/WeblateOrg/docker/blob/f54b83a0898bef9d14b00d885f675c2e4ebb68ca/Dockerfile#L1)