### PR TITLE
[UPD] remove OCA modules versions 8 to 10 from the auto-populate script

### DIFF
--- a/wocg-oca
+++ b/wocg-oca
@@ -6,7 +6,7 @@ from tools.oca_projects import get_repositories_and_branches
 
 
 def branch_filter(branch):
-    return is_main_branch(branch) and branch not in ("6.1", "7.0")
+    return is_main_branch(branch) and branch not in ("6.1", "7.0", "8.0", "9.0", "10.0")
 
 
 for repo, branch in get_repositories_and_branches(branch_filter=branch_filter):


### PR DESCRIPTION
@sbidoul I just removed version 8 to 10 from the script here, as announced a few months back (https://odoo-community.org/groups/contributors-15/contributors-1081457)